### PR TITLE
Fixes failing LocatorTest.findsThingsAtAGivenPosition

### DIFF
--- a/src/main/java/org/nusco/narjillos/application/utilities/Locator.java
+++ b/src/main/java/org/nusco/narjillos/application/utilities/Locator.java
@@ -5,9 +5,16 @@ import java.util.List;
 
 import org.nusco.narjillos.core.physics.Vector;
 import org.nusco.narjillos.core.things.Thing;
+import org.nusco.narjillos.creature.Egg;
+import org.nusco.narjillos.creature.Narjillo;
 import org.nusco.narjillos.ecosystem.Culture;
 
+/**
+ * Provides methods to find {@link Thing}s in a {@link Culture}.
+ */
 public class Locator {
+
+	private static final double DEFAULT_RADIUS = 100D;
 
 	private final Culture culture;
 
@@ -15,24 +22,68 @@ public class Locator {
 		this.culture = culture;
 	}
 
+	/**
+	 * Finds a {@link Thing} in a {@link Culture} using a custom minimum radius for the Thing.
+	 * <p>
+	 * The minimum radius is used to artificially <i>enlarge</i> the things being searched
+	 * allowing better control on the precision of the search process.
+	 *
+	 * @param position where to find a Thing.
+	 * @param thingMinRadius while searching, the radius of things is boosted to this value if smaller.
+	 * @return the first found Thing or null if nothing is present at the given position.
+	 */
+	public Thing findThingAt(Vector position, double thingMinRadius) {
+		Thing result = findWithLabel(position, thingMinRadius, "food");
+
+		if (result != null)
+			return result;
+
+		result = findWithLabel(position, thingMinRadius, "egg");
+
+		if (result != null)
+			return result;
+
+		return findNarjilloAt(position, thingMinRadius);
+	}
+
+	/**
+	 * Finds a {@link Thing} in a {@link Culture} using the default minimum radius of 100.
+	 *
+	 * @param position where to find a Thing.
+	 * @return the found Thing or null if nothing is present at the given position.
+	 */
 	public Thing findThingAt(Vector position) {
-		Thing result = findThingAt_WithLabel(position, "food");
-
-		if (result != null)
-			return result;
-
-		result = findThingAt_WithLabel(position, "egg");
-
-		if (result != null)
-			return result;
-
-		return findNarjilloAt(position);
+		return findThingAt(position, DEFAULT_RADIUS);
 	}
 
+	/**
+	 * Finds a {@link Narjillo} in a {@link Culture} using a custom minimum radius for the Thing.
+	 * <p>
+	 * The minimum radius is used to artificially <i>enlarge</i> the things being searched
+	 * allowing better control on the precision of the search process.
+	 *
+	 * @param position where to find a Thing.
+	 * @param thingMinRadius while searching, the radius of things is boosted to this value if smaller.
+	 * @return the found Narjillo or null if nothing is present at the given position.
+	 */
+	public Thing findNarjilloAt(Vector position, double thingMinRadius) {
+		return findWithLabel(position, thingMinRadius, "narjillo");
+	}
+
+	/**
+	 * Finds a {@link Narjillo} in a {@link Culture} using the default minimum radius of 100.
+	 *
+	 * @param position where to find a Thing.
+	 * @return the found Narjillo or null if nothing is present at the given position.
+	 */
 	public Thing findNarjilloAt(Vector position) {
-		return findThingAt_WithLabel(position, "narjillo");
+		return findWithLabel(position, DEFAULT_RADIUS, "narjillo");
 	}
 
+	/**
+	 * Returns a random {@link Narjillo} or {@link Egg} in the {@link Culture}.
+	 * @return the found thing.
+	 */
 	public Thing findRandomLivingThing() {
 		List<Thing> allThings = new LinkedList<>();
 		allThings.addAll(culture.getThings("narjillo"));
@@ -40,13 +91,14 @@ public class Locator {
 		return allThings.get((int)(Math.random() * allThings.size()));
 	}
 
-	private Thing findThingAt_WithLabel(Vector position, String label) {
+	private Thing findWithLabel(Vector position, double thingMinRadius, String label) {
 		Thing result = null;
 		double minDistance = Double.MAX_VALUE;
 
 		for (Thing thing : culture.getThings(label)) {
 			double distance = thing.getCenter().minus(position).getLength();
-			double radius = Math.max(thing.getRadius(), 100);
+			double radius = Math.max(thing.getRadius(), thingMinRadius);
+
 			if (distance < radius && distance < minDistance) {
 				minDistance = distance;
 				result = thing;

--- a/src/test/java/org/nusco/narjillos/application/utilities/LocatorTest.java
+++ b/src/test/java/org/nusco/narjillos/application/utilities/LocatorTest.java
@@ -14,11 +14,11 @@ import org.nusco.narjillos.ecosystem.Ecosystem;
 import org.nusco.narjillos.genomics.DNA;
 
 public class LocatorTest {
-	
+
 	Ecosystem ecosystem;
 	Locator locator;
 	RanGen ranGen = new RanGen(1234);
-	
+
 	@Before
 	public void initialize() {
 		ecosystem = new Ecosystem(1000, false);
@@ -26,35 +26,51 @@ public class LocatorTest {
 	}
 
 	private Narjillo insertNarjillo(Vector position) {
+		// the position specifies the head position; the body center will be different
 		DNA dna = new DNA(1, "{145_227_116_072_163_201_077_221_217}{060_227_157_252_209_149_056_114_167}{250_253_092_189_010_247_016_214_009}{027_039_203_179_042_042_175_110_008}");
 		Narjillo narjillo = new Narjillo(dna, position, 90, Energy.INFINITE);
 		ecosystem.insertNarjillo(narjillo);
 		return narjillo;
 	}
-	
+
 	@Test
 	public void findsThingsAtAGivenPosition() {
 		Narjillo narjillo1 = insertNarjillo(Vector.cartesian(1000, 1000));
 		Narjillo narjillo2 = insertNarjillo(Vector.cartesian(100, 100));
+
+		// the narjillos have radius = 2.5
 		assertTrue(narjillo1.getRadius() > 2 && narjillo1.getRadius() < 3);
 		assertTrue(narjillo2.getRadius() > 2 && narjillo2.getRadius() < 3);
 
-		assertNull(locator.findNarjilloAt(Vector.cartesian(103, 103)));
-		assertEquals(narjillo2, locator.findNarjilloAt(Vector.cartesian(102, 102)));
-		assertEquals(narjillo1, locator.findNarjilloAt(Vector.cartesian(998, 1002)));
+		// point 4.24 units away from head, 3.04 from center
+		assertNull(locator.findNarjilloAt(Vector.cartesian(103, 103), 1));
+
+		// point 2.82 units away from head, 2.06 from center (-> within the radius)
+		assertEquals(narjillo2, locator.findNarjilloAt(Vector.cartesian(102, 102), 1));
+		assertEquals(narjillo1, locator.findNarjilloAt(Vector.cartesian(998, 1002), 1));
 	}
-	
+
+	@Test
+	public void findsExpandedNarjillo() {
+		Narjillo narjillo1 = insertNarjillo(Vector.cartesian(100, 100));
+
+		// original narjillo -> radius = 2.5
+		assertNull(locator.findNarjilloAt(Vector.cartesian(110, 110), 1));
+		// expanded narjillo -> radius = 20
+		assertEquals(narjillo1, locator.findNarjilloAt(Vector.cartesian(110, 110), 20));
+	}
+
 	@Test
 	public void returnsNullIfNoThingIsCloseEnough() {
 		insertNarjillo(Vector.cartesian(100, 10));
-		
+
 		assertNull(locator.findNarjilloAt(Vector.cartesian(500, 500)));
 	}
 
 	@Test
 	public void returnsNullIfTheEcosystemContainsNoNarjillos() {
 		Locator emptyLocator = new Locator(new Ecosystem(1000, false));
-		
+
 		assertNull(emptyLocator.findNarjilloAt(Vector.cartesian(150, 150)));
 	}
 }


### PR DESCRIPTION
The LocatorTest.findsThingsAtAGivenPosition test was failing because the Locator.findThingAt_WithLabel method was using a floor value of 100 for the size of a Thing.

Finding things at distances below this lower threshold was always succeeding while the test expected nothing to be found in one assert statement.  